### PR TITLE
add poster/art to movies so that krypton views show properly

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+/.project
+/.pydevproject
+/.settings
+*.pyc
+*.pyo

--- a/addon.py
+++ b/addon.py
@@ -53,7 +53,8 @@ def show_movies():
     )
     items = get_movies3(source, limit)
     finish_kwargs = {
-        'sort_methods': ['date', 'title', 'playlist_order']
+        'sort_methods': ['date', 'title', 'playlist_order'],
+        'cache_to_disc': False
     }
     return plugin.finish(items, **finish_kwargs)
 
@@ -147,6 +148,11 @@ def get_movies3(source, limit):
     items = [{
         'label': movie['title'],
         'thumbnail': movie['poster'],
+        'art': {
+            'thumbnail': movie['poster'],
+            'poster': movie['poster'],
+            'fanart': movie['background'],
+        },
         'info': {
             'count': i,
             'title': movie['title'],

--- a/resources/lib/scraper.py
+++ b/resources/lib/scraper.py
@@ -134,18 +134,21 @@ class TrailerScraper(object):
         tree = self.__get_tree(self.TRAILERS_URL % location)
         for li in tree.findAll('li', {'class': re.compile('trailer')}):
             slug = li.find('h3').string.replace(' ', '').replace('-', '').lower()
-            playlist = self.__get_url(self.PLAY_LIST_URL % (location, slug))
-            trailer_url = re.search(self.RE_URL, playlist).group(1)
-            duration = int(re.search(self.RE_DURATION, playlist).group(1)) / 1000
-            trailer = {
-                'title': li.find('h3').string,
-                'date': '',
-                'duration': duration,
-                'thumb': __thumb(li.find('img')['src']),
-                'background': self.BACKGROUND_URL % location,
-                'urls': __trailer_urls(trailer_url)
-            }
-            yield trailer
+            try:
+                playlist = self.__get_url(self.PLAY_LIST_URL % (location, slug))
+                trailer_url = re.search(self.RE_URL, playlist).group(1)
+                duration = int(re.search(self.RE_DURATION, playlist).group(1)) / 1000
+                trailer = {
+                    'title': li.find('h3').string,
+                    'date': '',
+                    'duration': duration,
+                    'thumb': __thumb(li.find('img')['src']),
+                    'background': self.BACKGROUND_URL % location,
+                    'urls': __trailer_urls(trailer_url)
+                }
+                yield trailer
+            except NetworkError:
+                pass
 
     def __get_tree(self, url):
         return BeautifulSoup(self.__get_url(url))
@@ -157,7 +160,6 @@ class TrailerScraper(object):
         try:
             return urllib2.urlopen(req).read()
         except urllib2.HTTPError, error:
-            print error
             raise NetworkError('HTTPError: %s' % error)
 
 


### PR DESCRIPTION
Views in Krypton that use posters are not working properly because xbmcswift2 doesn't call listitem.setArt(). This is the itunes_trailer side of the fix for this issue.

This also needs a small update to xbmcswift2 to allow the art dict to be passed in. How should I handle that? It looks like it's been about 2 years since xbmcswift has been updated. The changes are pretty minor.
